### PR TITLE
Add safe and fast vectors

### DIFF
--- a/include/phase4/engine/common/castling.h
+++ b/include/phase4/engine/common/castling.h
@@ -1,6 +1,8 @@
 #ifndef PHASE4_ENGINE_COMMON_CASTLING_H
 #define PHASE4_ENGINE_COMMON_CASTLING_H
 
+#include <phase4/engine/common/util.h>
+
 #include <cstdint>
 #include <iostream>
 
@@ -17,51 +19,42 @@ enum Castling : uint8_t {
 	EVERYTHING = WHITE_SHORT | WHITE_LONG | BLACK_SHORT | BLACK_LONG
 };
 
-std::ostream &operator<<(std::ostream &os, const Castling &castling) {
+std::ostream &operator<<(std::ostream &os, Castling castling) {
 	switch (castling) {
 		case Castling::NONE:
-			os << "NONE";
-			break;
+			return os << "NONE";
 		case Castling::WHITE_SHORT:
-			os << "WHITE_SHORT";
-			break;
+			return os << "WHITE_SHORT";
 		case Castling::WHITE_LONG:
-			os << "WHITE_LONG";
-			break;
+			return os << "WHITE_LONG";
 		case Castling::BLACK_SHORT:
-			os << "BLACK_SHORT";
-			break;
+			return os << "BLACK_SHORT";
 		case Castling::BLACK_LONG:
-			os << "BLACK_LONG";
-			break;
+			return os << "BLACK_LONG";
 		case Castling::WHITE_CASTLING:
-			os << "WHITE_CASTLING";
-			break;
+			return os << "WHITE_CASTLING";
 		case Castling::BLACK_CASTLING:
-			os << "BLACK_CASTLING";
-			break;
+			return os << "BLACK_CASTLING";
 		case Castling::EVERYTHING:
-			os << "EVERYTHING";
-			break;
+			return os << "EVERYTHING";
 		default:
-			if (castling > EVERYTHING) {
+			if (unlikely(castling > EVERYTHING)) {
 				os.setstate(std::ios_base::failbit);
-				return os;
-			}
+			} else {
+				bool isFirstFlag = true;
 
-			bool isFirstFlag = true;
-
-			for (uint8_t flag = 1; flag <= EVERYTHING; flag <<= 1) {
-				if (castling & flag) {
-					if (!isFirstFlag) {
-						os << " | ";
+				for (uint8_t flag = 1; flag <= EVERYTHING; flag <<= 1) {
+					if (castling & flag) {
+						if (!isFirstFlag) {
+							os << " | ";
+						}
+						os << static_cast<Castling>(flag);
+						isFirstFlag = false;
 					}
-					os << static_cast<Castling>(flag);
-					isFirstFlag = false;
 				}
 			}
+			return os;
 	}
-	return os;
 }
 
 } //namespace phase4::engine::common

--- a/include/phase4/engine/common/fast_vector.h
+++ b/include/phase4/engine/common/fast_vector.h
@@ -7,9 +7,9 @@
 
 namespace phase4::engine::common {
 
-/// @brief Provides a fixed size std::vector
-/// @tparam T element type used for the vector
-/// @tparam SIZE the capacity of the vector
+/// @brief Provides a fixed capacity std::array with a size
+/// @tparam T element type used for the array
+/// @tparam SIZE the capacity of the array
 template <typename T, std::size_t SIZE = 1024>
 class FastVector {
 public:
@@ -21,6 +21,11 @@ public:
 	void push_back(T &&value);
 
 	T &&pop_back();
+
+	void clear();
+
+	const T &at(std::size_t index) const;
+	const T &peek() const;
 
 	std::size_t size() const;
 	bool is_empty() const;
@@ -56,6 +61,25 @@ T &&FastVector<T, SIZE>::pop_back() {
 	assert(!is_empty());
 
 	return std::move((*m_array)[--m_size]);
+}
+
+template <typename T, std::size_t SIZE>
+void FastVector<T, SIZE>::clear() {
+	m_size = 0;
+}
+
+template <typename T, std::size_t SIZE>
+const T &FastVector<T, SIZE>::at(std::size_t index) const {
+	assert(index < m_size);
+
+	return (*m_array)[index];
+}
+
+template <typename T, std::size_t SIZE>
+const T &FastVector<T, SIZE>::peek() const {
+	assert(!is_empty());
+
+	return (*m_array)[m_size - 1];
 }
 
 template <typename T, std::size_t SIZE>

--- a/include/phase4/engine/common/fast_vector.h
+++ b/include/phase4/engine/common/fast_vector.h
@@ -1,0 +1,71 @@
+#include <phase4/engine/common/util.h>
+
+#include <array>
+#include <cassert>
+#include <memory>
+#include <memory_resource>
+
+namespace phase4::engine::common {
+
+/// @brief Provides a fixed size std::vector
+/// @tparam T element type used for the vector
+/// @tparam SIZE the capacity of the vector
+template <typename T, std::size_t SIZE = 1024>
+class FastVector {
+public:
+	/// @brief
+	/// @param upstream the upstream std::memory_resource if allocation is requried
+	FastVector(std::pmr::memory_resource *upstream = std::pmr::get_default_resource());
+
+	void push_back(const T &value);
+	void push_back(T &&value);
+
+	T &&pop_back();
+
+	std::size_t size() const;
+	bool is_empty() const;
+
+private:
+	using Buffer = std::array<T, SIZE>;
+
+	UniquePtr<Buffer> m_array;
+	std::size_t m_size = 0;
+};
+
+template <typename T, std::size_t SIZE>
+FastVector<T, SIZE>::FastVector(std::pmr::memory_resource *upstream) :
+		m_array(allocate_unique<Buffer>(upstream)) {
+}
+
+template <typename T, std::size_t SIZE>
+void FastVector<T, SIZE>::push_back(const T &value) {
+	assert(m_size < SIZE);
+
+	m_array[m_size++] = value;
+}
+
+template <typename T, std::size_t SIZE>
+void FastVector<T, SIZE>::push_back(T &&value) {
+	assert(m_size < SIZE);
+
+	(*m_array)[m_size++] = std::move(value);
+}
+
+template <typename T, std::size_t SIZE>
+T &&FastVector<T, SIZE>::pop_back() {
+	assert(!is_empty());
+
+	return std::move((*m_array)[--m_size]);
+}
+
+template <typename T, std::size_t SIZE>
+std::size_t FastVector<T, SIZE>::size() const {
+	return m_size;
+}
+
+template <typename T, std::size_t SIZE>
+bool FastVector<T, SIZE>::is_empty() const {
+	return m_size == 0;
+}
+
+} //namespace phase4::engine::common

--- a/include/phase4/engine/common/field_index.h
+++ b/include/phase4/engine/common/field_index.h
@@ -44,11 +44,11 @@ constexpr uint16_t FieldIndex::manhattanDistance(const FieldIndex &other) const 
 	return std::max(std::abs(other.x - this->x), std::abs(other.y - this->y));
 }
 
-inline bool operator==(const FieldIndex &left, const FieldIndex &right) {
+inline bool operator==(const FieldIndex left, const FieldIndex right) {
 	return left.x == right.x && left.y == right.y;
 }
 
-inline std::ostream &operator<<(std::ostream &os, const FieldIndex &fieldIndex) {
+inline std::ostream &operator<<(std::ostream &os, const FieldIndex fieldIndex) {
 	return os << "x:" << fieldIndex.x << ", y:" << fieldIndex.y;
 }
 

--- a/include/phase4/engine/common/game_phase.h
+++ b/include/phase4/engine/common/game_phase.h
@@ -1,4 +1,9 @@
 #ifndef PHASE4_ENGINE_COMMON_GAME_PHASE_H
 #define PHASE4_ENGINE_COMMON_GAME_PHASE_H
 
+enum GamePhase {
+	OPENING,
+	ENDING,
+};
+
 #endif

--- a/include/phase4/engine/common/piece_color.h
+++ b/include/phase4/engine/common/piece_color.h
@@ -17,7 +17,7 @@ public:
 
 	/// @brief inverts the color
 	/// @return the inverted color
-	[[nodiscard]] constexpr inline PieceColor invert() const;
+	[[nodiscard]] constexpr inline PieceColor invert() const noexcept;
 
 	constexpr PieceColor(PieceColor const &that);
 	constexpr PieceColor &operator=(const PieceColor &that);
@@ -27,7 +27,7 @@ public:
 
 	constexpr bool operator==(const PieceColor &) const;
 
-	friend std::ostream &operator<<(std::ostream &os, const PieceColor &color);
+	friend std::ostream &operator<<(std::ostream &os, PieceColor color);
 
 private:
 	constexpr PieceColor(uint64_t value);
@@ -36,7 +36,7 @@ private:
 	uint8_t m_value;
 };
 
-[[nodiscard]] constexpr inline PieceColor PieceColor::invert() const {
+[[nodiscard]] constexpr inline PieceColor PieceColor::invert() const noexcept {
 	if ((*this) == WHITE) {
 		return BLACK;
 	} else {
@@ -82,18 +82,16 @@ constexpr bool PieceColor::operator==(const PieceColor &color) const {
 	return color.m_value == m_value;
 }
 
-std::ostream &operator<<(std::ostream &os, const PieceColor &color) {
+std::ostream &operator<<(std::ostream &os, PieceColor color) {
 	switch (color.m_value) {
 		case PieceColor::WHITE.m_value:
-			os << "WHITE";
-			break;
+			return os << "WHITE";
 		case PieceColor::BLACK.m_value:
-			os << "BLACK";
-			break;
+			return os << "BLACK";
 		default:
 			os.setstate(std::ios_base::failbit);
+			return os;
 	}
-	return os;
 }
 
 } //namespace phase4::engine::common

--- a/include/phase4/engine/common/piece_type.h
+++ b/include/phase4/engine/common/piece_type.h
@@ -28,7 +28,7 @@ public:
 
 	constexpr bool operator==(const PieceType &) const;
 
-	friend std::ostream &operator<<(std::ostream &os, const PieceType &color);
+	friend std::ostream &operator<<(std::ostream &os, PieceType color);
 
 private:
 	constexpr PieceType(uint64_t value);
@@ -74,6 +74,26 @@ constexpr PieceType &PieceType::operator=(PieceType &&that) noexcept {
 
 [[nodiscard]] constexpr uint8_t PieceType::get_raw_value() const {
 	return m_piece;
+}
+
+inline std::ostream &operator<<(std::ostream &os, PieceType color) {
+	switch (color.m_piece) {
+		case PieceType::PAWN.m_piece:
+			return os << "PAWN";
+		case PieceType::KNIGHT.m_piece:
+			return os << "KNIGHT";
+		case PieceType::BISHOP.m_piece:
+			return os << "BISHOP";
+		case PieceType::ROOK.m_piece:
+			return os << "ROOK";
+		case PieceType::QUEEN.m_piece:
+			return os << "QUEEN";
+		case PieceType::KING.m_piece:
+			return os << "KING";
+		default:
+			os.setstate(std::ios_base::failbit);
+			return os;
+	}
 }
 
 } //namespace phase4::engine::common

--- a/include/phase4/engine/common/safe_vector.h
+++ b/include/phase4/engine/common/safe_vector.h
@@ -20,6 +20,11 @@ public:
 
 	T &&pop_back();
 
+	void clear();
+
+	const T &at(std::size_t index) const;
+	const T &peek() const;
+
 	std::size_t size() const;
 	bool is_empty() const;
 
@@ -53,6 +58,23 @@ T &&SafeVector<T, SIZE>::pop_back() {
 	T &&back = std::move(m_vector.back());
 	m_vector.pop_back();
 	return std::move(back);
+}
+
+template <typename T, std::size_t SIZE>
+void SafeVector<T, SIZE>::clear() {
+	m_vector.clear();
+}
+
+template <typename T, std::size_t SIZE>
+const T &SafeVector<T, SIZE>::at(std::size_t index) const {
+	return m_vector.at(index);
+}
+
+template <typename T, std::size_t SIZE>
+const T &SafeVector<T, SIZE>::peek() const {
+	assert(!m_vector.empty());
+
+	return m_vector[size() - 1];
 }
 
 template <typename T, std::size_t SIZE>

--- a/include/phase4/engine/common/safe_vector.h
+++ b/include/phase4/engine/common/safe_vector.h
@@ -1,0 +1,68 @@
+#include <array>
+#include <cassert>
+#include <memory_resource>
+#include <vector>
+
+namespace phase4::engine::common {
+
+/// @brief Provides a fixed size std::vector that can reallocate memory if needed
+/// @tparam T element type used for the vector
+/// @tparam SIZE the capacity of the vector
+template <typename T, std::size_t SIZE = 1024>
+class SafeVector {
+public:
+	/// @brief
+	/// @param upstream the upstream std::memory_resource if allocation is requried
+	SafeVector(std::pmr::memory_resource *upstream = std::pmr::null_memory_resource());
+
+	void push_back(const T &value);
+	void push_back(T &&value);
+
+	T &&pop_back();
+
+	std::size_t size() const;
+	bool is_empty() const;
+
+private:
+	std::array<T, SIZE> m_buffer;
+	std::pmr::monotonic_buffer_resource m_pool;
+	std::pmr::vector<T> m_vector;
+};
+
+template <typename T, std::size_t SIZE>
+SafeVector<T, SIZE>::SafeVector(std::pmr::memory_resource *upstream) :
+		m_pool(m_buffer.data(), sizeof(m_buffer), upstream),
+		m_vector(&m_pool) {
+	m_vector.reserve(SIZE);
+}
+
+template <typename T, std::size_t SIZE>
+void SafeVector<T, SIZE>::push_back(const T &value) {
+	m_vector.push_back(value);
+}
+
+template <typename T, std::size_t SIZE>
+void SafeVector<T, SIZE>::push_back(T &&value) {
+	m_vector.push_back(std::move(value));
+}
+
+template <typename T, std::size_t SIZE>
+T &&SafeVector<T, SIZE>::pop_back() {
+	assert(!m_vector.empty());
+
+	T &&back = std::move(m_vector.back());
+	m_vector.pop_back();
+	return std::move(back);
+}
+
+template <typename T, std::size_t SIZE>
+std::size_t SafeVector<T, SIZE>::size() const {
+	return m_vector.size();
+}
+
+template <typename T, std::size_t SIZE>
+bool SafeVector<T, SIZE>::is_empty() const {
+	return m_vector.empty();
+}
+
+} //namespace phase4::engine::common

--- a/include/phase4/engine/common/square.h
+++ b/include/phase4/engine/common/square.h
@@ -2,6 +2,7 @@
 #define PHASE4_ENGINE_COMMON_SQUARE_H
 
 #include <phase4/engine/common/field_index.h>
+#include <phase4/engine/common/util.h>
 
 #include <iostream>
 
@@ -229,7 +230,7 @@ inline std::ostream &operator<<(std::ostream &os, const Square &square) {
 	const int16_t file = square.m_value / 8;
 	const int16_t rank = square.m_value % 8;
 
-	if (file >= 0 && file < 8 && rank >= 0 && rank < 8) {
+	if (unlikely(file >= 0 && file < 8 && rank >= 0 && rank < 8)) {
 		os << fileLabels[file] << (rank + 1);
 	} else {
 		os.setstate(std::ios_base::failbit);

--- a/include/phase4/engine/common/util.h
+++ b/include/phase4/engine/common/util.h
@@ -1,0 +1,36 @@
+#include <memory>
+#include <memory_resource>
+
+#if defined(__GNUC__)
+#define likely(x) __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
+#else
+#define likely(x) x
+#define unlikely(x) x
+#endif
+
+template <typename T>
+struct UniquePtrDeleter {
+	UniquePtrDeleter(std::pmr::memory_resource *alloc) :
+			allocator(alloc) {}
+
+	void operator()(T *ptr) const {
+		if (ptr) {
+			ptr->~T(); // Call the destructor
+			allocator->deallocate(ptr, 1); // Deallocate memory using the custom allocator
+		}
+	}
+
+private:
+	std::pmr::memory_resource *allocator;
+};
+
+template <typename T>
+using UniquePtr = std::unique_ptr<T, UniquePtrDeleter<T>>;
+
+template <typename T, typename... Args>
+UniquePtr<T> allocate_unique(std::pmr::memory_resource *allocator, Args &&...args) {
+	UniquePtrDeleter<T> customDeleter(allocator);
+
+	return std::unique_ptr<T, UniquePtrDeleter<T>>(new (allocator->allocate(sizeof(T), alignof(T))) T(std::forward<Args>(args)...), customDeleter);
+}

--- a/include/phase4/engine/common/vector.h
+++ b/include/phase4/engine/common/vector.h
@@ -1,0 +1,15 @@
+#ifdef NDEBUG
+#include <phase4/engine/common/safe_vector.h>
+#else
+#include <phase4/engine/common/fast_vector.h>
+#endif
+
+namespace phase4::engine::common {
+
+#ifdef NDEBUG
+using Vector = SafeVector;
+#else
+using Vector = FastVector;
+#endif
+
+} //namespace phase4::engine::common

--- a/include/phase4/engine/moves/move.h
+++ b/include/phase4/engine/moves/move.h
@@ -64,7 +64,7 @@ constexpr Move::Move(std::string_view textNotation) :
 
 std::ostream &operator<<(std::ostream &os, const Move &move) {
 	os << common::Square(move.from()) << common::Square(move.to());
-	if (move.flags().isPromotion()) {
+	if (unlikely(move.flags().isPromotion())) {
 		os << move.flags().getPromotionSymbol();
 	}
 	return os;

--- a/include/phase4/engine/moves/move_flags.h
+++ b/include/phase4/engine/moves/move_flags.h
@@ -227,52 +227,37 @@ constexpr bool MoveFlags::operator==(const MoveFlags &flags) const {
 inline std::ostream &operator<<(std::ostream &os, const MoveFlags &flags) {
 	switch (flags.m_flags) {
 		case MoveFlags::QUIET.m_flags:
-			os << "QUIET";
-			break;
+			return os << "QUIET";
 		case MoveFlags::DOUBLE_PUSH.m_flags:
-			os << "DOUBLE_PUSH";
-			break;
+			return os << "DOUBLE_PUSH";
 		case MoveFlags::KING_CASTLE.m_flags:
-			os << "KING_CASTLE";
-			break;
+			return os << "KING_CASTLE";
 		case MoveFlags::QUEEN_CASTLE.m_flags:
-			os << "QUEEN_CASTLE";
-			break;
+			return os << "QUEEN_CASTLE";
 		case MoveFlags::CAPTURE.m_flags:
-			os << "CAPTURE";
-			break;
+			return os << "CAPTURE";
 		case MoveFlags::EN_PASSANT.m_flags:
-			os << "EN_PASSANT";
-			break;
+			return os << "EN_PASSANT";
 		case MoveFlags::KNIGHT_PROMOTION.m_flags:
-			os << "KNIGHT_PROMOTION";
-			break;
+			return os << "KNIGHT_PROMOTION";
 		case MoveFlags::BISHOP_PROMOTION.m_flags:
-			os << "BISHOP_PROMOTION";
-			break;
+			return os << "BISHOP_PROMOTION";
 		case MoveFlags::ROOK_PROMOTION.m_flags:
-			os << "ROOK_PROMOTION";
-			break;
+			return os << "ROOK_PROMOTION";
 		case MoveFlags::QUEEN_PROMOTION.m_flags:
-			os << "QUEEN_PROMOTION";
-			break;
+			return os << "QUEEN_PROMOTION";
 		case MoveFlags::KNIGHT_PROMOTION_CAPTURE.m_flags:
-			os << "KNIGHT_PROMOTION_CAPTURE";
-			break;
+			return os << "KNIGHT_PROMOTION_CAPTURE";
 		case MoveFlags::BISHOP_PROMOTION_CAPTURE.m_flags:
-			os << "BISHOP_PROMOTION_CAPTURE";
-			break;
+			return os << "BISHOP_PROMOTION_CAPTURE";
 		case MoveFlags::ROOK_PROMOTION_CAPTURE.m_flags:
-			os << "ROOK_PROMOTION_CAPTURE";
-			break;
+			return os << "ROOK_PROMOTION_CAPTURE";
 		case MoveFlags::QUEEN_PROMOTION_CAPTURE.m_flags:
-			os << "QUEEN_PROMOTION_CAPTURE";
-			break;
+			return os << "QUEEN_PROMOTION_CAPTURE";
 		default:
 			os.setstate(std::ios_base::failbit);
-			break;
+			return os;
 	}
-	return os;
 }
 
 } //namespace phase4::engine::moves

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,9 +6,11 @@ add_executable(phase4_test
     phase4/engine/common/bitset.t.cpp
     phase4/engine/common/castling.t.cpp
     phase4/engine/common/distance.t.cpp
+    phase4/engine/common/fast_vector.t.cpp
     phase4/engine/common/piece_color.t.cpp
     phase4/engine/common/piece_type.t.cpp
     phase4/engine/common/random.t.cpp
+    phase4/engine/common/safe_vector.t.cpp
     phase4/engine/common/square.t.cpp
     phase4/engine/moves/move.t.cpp
     phase4/engine/moves/move_flags.t.cpp

--- a/tests/phase4/engine/common/fast_vector.t.cpp
+++ b/tests/phase4/engine/common/fast_vector.t.cpp
@@ -16,19 +16,26 @@ TEST_CASE("FastVector constructor") {
 	}
 }
 
-TEST_CASE("FastVector push_back") {
+TEST_CASE("FastVector push_back, pop_back, peek") {
 	using namespace phase4::engine::common;
 
 	FastVector<uint64_t, 4> numbers;
 	numbers.push_back(5);
+	CHECK(numbers.peek() == 5);
 	numbers.push_back(4);
+	CHECK(numbers.peek() == 4);
 	numbers.push_back(3);
+	CHECK(numbers.peek() == 3);
 	numbers.push_back(2);
+	CHECK(numbers.peek() == 2);
 
 	CHECK(numbers.pop_back() == 2);
+	CHECK(numbers.peek() == 3);
 	CHECK(numbers.pop_back() == 3);
-	CHECK(numbers.pop_back() == 4);
-	CHECK(numbers.pop_back() == 5);
+	CHECK(numbers.peek() == 4);
+
+	numbers.clear();
+
 	CHECK(numbers.is_empty());
 }
 

--- a/tests/phase4/engine/common/fast_vector.t.cpp
+++ b/tests/phase4/engine/common/fast_vector.t.cpp
@@ -29,6 +29,9 @@ TEST_CASE("FastVector push_back, pop_back, peek") {
 	numbers.push_back(2);
 	CHECK(numbers.peek() == 2);
 
+    CHECK(numbers.at(1) == 4);
+    CHECK(numbers.at(3) == 2);
+
 	CHECK(numbers.pop_back() == 2);
 	CHECK(numbers.peek() == 3);
 	CHECK(numbers.pop_back() == 3);

--- a/tests/phase4/engine/common/fast_vector.t.cpp
+++ b/tests/phase4/engine/common/fast_vector.t.cpp
@@ -1,0 +1,50 @@
+#include <phase4/engine/common/fast_vector.h>
+
+#include <functional>
+
+#include <doctest/doctest.h>
+
+TEST_CASE("FastVector constructor") {
+	using namespace phase4::engine::common;
+
+	SUBCASE("No size") {
+		FastVector<uint64_t> numbers;
+	}
+
+	SUBCASE("Sized") {
+		FastVector<uint64_t, 256> numbers;
+	}
+}
+
+TEST_CASE("FastVector push_back") {
+	using namespace phase4::engine::common;
+
+	FastVector<uint64_t, 4> numbers;
+	numbers.push_back(5);
+	numbers.push_back(4);
+	numbers.push_back(3);
+	numbers.push_back(2);
+
+	CHECK(numbers.pop_back() == 2);
+	CHECK(numbers.pop_back() == 3);
+	CHECK(numbers.pop_back() == 4);
+	CHECK(numbers.pop_back() == 5);
+	CHECK(numbers.is_empty());
+}
+
+TEST_CASE("FastVector pop_back") {
+	using namespace phase4::engine::common;
+
+	uint64_t &&result = std::invoke([]() {
+		std::pmr::monotonic_buffer_resource memory_resource;
+		FastVector<uint64_t, 4> numbers(&memory_resource);
+		numbers.push_back(5);
+		numbers.push_back(4);
+		numbers.push_back(3);
+		numbers.push_back(2);
+
+		return numbers.pop_back();
+	});
+
+	CHECK(result == 2);
+}

--- a/tests/phase4/engine/common/fast_vector.t.cpp
+++ b/tests/phase4/engine/common/fast_vector.t.cpp
@@ -29,8 +29,8 @@ TEST_CASE("FastVector push_back, pop_back, peek") {
 	numbers.push_back(2);
 	CHECK(numbers.peek() == 2);
 
-    CHECK(numbers.at(1) == 4);
-    CHECK(numbers.at(3) == 2);
+	CHECK(numbers.at(1) == 4);
+	CHECK(numbers.at(3) == 2);
 
 	CHECK(numbers.pop_back() == 2);
 	CHECK(numbers.peek() == 3);

--- a/tests/phase4/engine/common/safe_vector.t.cpp
+++ b/tests/phase4/engine/common/safe_vector.t.cpp
@@ -29,6 +29,9 @@ TEST_CASE("SafeVector push_back, pop_back, peek") {
 	numbers.push_back(2);
 	CHECK(numbers.peek() == 2);
 
+    CHECK(numbers.at(1) == 4);
+    CHECK(numbers.at(3) == 2);
+
 	CHECK(numbers.pop_back() == 2);
 	CHECK(numbers.peek() == 3);
 	CHECK(numbers.pop_back() == 3);

--- a/tests/phase4/engine/common/safe_vector.t.cpp
+++ b/tests/phase4/engine/common/safe_vector.t.cpp
@@ -16,19 +16,25 @@ TEST_CASE("SafeVector constructor") {
 	}
 }
 
-TEST_CASE("SafeVector push_back") {
+TEST_CASE("SafeVector push_back, pop_back, peek") {
 	using namespace phase4::engine::common;
 
 	SafeVector<uint64_t, 4> numbers;
 	numbers.push_back(5);
+	CHECK(numbers.peek() == 5);
 	numbers.push_back(4);
+	CHECK(numbers.peek() == 4);
 	numbers.push_back(3);
+	CHECK(numbers.peek() == 3);
 	numbers.push_back(2);
+	CHECK(numbers.peek() == 2);
 
 	CHECK(numbers.pop_back() == 2);
+	CHECK(numbers.peek() == 3);
 	CHECK(numbers.pop_back() == 3);
-	CHECK(numbers.pop_back() == 4);
-	CHECK(numbers.pop_back() == 5);
+	CHECK(numbers.peek() == 4);
+
+	numbers.clear();
 	CHECK(numbers.is_empty());
 }
 

--- a/tests/phase4/engine/common/safe_vector.t.cpp
+++ b/tests/phase4/engine/common/safe_vector.t.cpp
@@ -29,8 +29,8 @@ TEST_CASE("SafeVector push_back, pop_back, peek") {
 	numbers.push_back(2);
 	CHECK(numbers.peek() == 2);
 
-    CHECK(numbers.at(1) == 4);
-    CHECK(numbers.at(3) == 2);
+	CHECK(numbers.at(1) == 4);
+	CHECK(numbers.at(3) == 2);
 
 	CHECK(numbers.pop_back() == 2);
 	CHECK(numbers.peek() == 3);

--- a/tests/phase4/engine/common/safe_vector.t.cpp
+++ b/tests/phase4/engine/common/safe_vector.t.cpp
@@ -1,0 +1,50 @@
+#include <phase4/engine/common/safe_vector.h>
+
+#include <functional>
+
+#include <doctest/doctest.h>
+
+TEST_CASE("SafeVector constructor") {
+	using namespace phase4::engine::common;
+
+	SUBCASE("No size") {
+		SafeVector<uint64_t> numbers;
+	}
+
+	SUBCASE("Sized") {
+		SafeVector<uint64_t, 256> numbers;
+	}
+}
+
+TEST_CASE("SafeVector push_back") {
+	using namespace phase4::engine::common;
+
+	SafeVector<uint64_t, 4> numbers;
+	numbers.push_back(5);
+	numbers.push_back(4);
+	numbers.push_back(3);
+	numbers.push_back(2);
+
+	CHECK(numbers.pop_back() == 2);
+	CHECK(numbers.pop_back() == 3);
+	CHECK(numbers.pop_back() == 4);
+	CHECK(numbers.pop_back() == 5);
+	CHECK(numbers.is_empty());
+}
+
+TEST_CASE("SafeVector pop_back") {
+	using namespace phase4::engine::common;
+
+	uint64_t &&result = std::invoke([]() {
+		std::pmr::monotonic_buffer_resource memory_resource;
+		SafeVector<uint64_t, 4> numbers(&memory_resource);
+		numbers.push_back(5);
+		numbers.push_back(4);
+		numbers.push_back(3);
+		numbers.push_back(2);
+
+		return numbers.pop_back();
+	});
+
+	CHECK(result == 2);
+}


### PR DESCRIPTION
Added
* `FastVector`
  * Allocates memory once and uses `std::array` as a buffer.
* `SafeVector`
  * Allocates memory upfront but can be expanded using a `std::vector` as a buffer.

Light refactoring:
* ostream operators to reduce number of LoC
* removing `const` from smaller types like `uint8_t`, `uint16_t`, etc.